### PR TITLE
Fix undefined method error when voting up

### DIFF
--- a/lib/acts_as_voteable.rb
+++ b/lib/acts_as_voteable.rb
@@ -29,7 +29,7 @@ module Juixe
       # This module contains instance methods
       module InstanceMethods
         def vote( vote=:up, user=User.current )
-          return if (voted_by_user? user && !user.allowed_to?(:multiple_vote_issue, nil, options={:global => true}))
+          return if (voted_by_user?(user) && !user.allowed_to?(:multiple_vote_issue, nil, options={:global => true}))
           Vote.create( :voteable => self, :vote => vote == :up, :user => user ) 
           self.votes_value += (vote == :up ? 1:-1)
         end


### PR DESCRIPTION
<pre>
NoMethodError (undefined method `id' for true:TrueClass):
  plugins/redmine_vote/lib/acts_as_voteable.rb:60:in `block in voted_by_user?'
  vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.19/lib/active_record/associations/collection_proxy.rb:91:in `each'
  vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.19/lib/active_record/associations/collection_proxy.rb:91:in `method_missing'
  plugins/redmine_vote/lib/acts_as_voteable.rb:59:in `voted_by_user?'
  plugins/redmine_vote/lib/acts_as_voteable.rb:32:in `vote'
</pre>
